### PR TITLE
Added support for custom actions and filters

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -150,6 +150,16 @@ fail2ban_default_actions:
 # Dict with custom set of named actions to perform when a ban is executed.
 fail2ban_custom_actions: {}
 
+# .. envvar:: fail2ban_actions
+#
+# List of dicts which define custom local ``fail2ban`` actions.
+fail2ban_actions: []
+
+# .. envvar:: fail2ban_filters
+#
+# List of dicts which define custom local ``fail2ban`` filters.
+fail2ban_filters: []
+
 
 # --------------------------
 #   List of fail2ban jails

--- a/docs/defaults-configuration.rst
+++ b/docs/defaults-configuration.rst
@@ -9,6 +9,81 @@ them.
    :local:
    :depth: 1
 
+.. _fail2ban_actions:
+
+fail2ban_actions
+----------------
+
+List of local ``fail2ban`` actions that should be present or absent when configuring
+``fail2ban``. Each action is defined as a YAML dict with the following keys:
+
+``name``
+  Required. Name of the filter.
+
+``ban``
+  Required. Command executed when banning an IP. Take care that the command is executed
+  with ``fail2ban`` user rights.
+
+``check``
+  Optional. Command executed once before each ``ban`` command.
+
+``filename``
+  Optional. Alternative name of the action configuration file.
+
+``start``
+  Optional. Command executed once at the start of ``fail2ban``.
+
+``state``
+  Optional. If ``present``, the action will be created when configuring ``fail2ban``.
+  If ``absent``, the action will be removed when configuring ``fail2ban``.
+
+``stop``
+  Optional. Command executed once at the end of ``fail2ban``.
+
+``unban``
+  Optional. Command executed when unbanning an IP. Take care that the command is executed
+  with ``fail2ban`` user rights.
+
+.. _fail2ban_filters:
+
+fail2ban_filters
+----------------
+
+List of local ``fail2ban`` filters that should be present or absent when configuring
+``fail2ban``. Each filter is defined as a YAML dict with the following keys:
+
+``name``
+  Required. Name of the filter.
+
+``after``
+  Optional. Specify an addtional filter configuration file that ``fail2ban`` will
+  read after reading this filter configuration filer.
+
+``before``
+  Optional. Specify an addtional filter configuration file that ``fail2ban`` will
+  read before reading this filter configuration file.
+
+``definitions``
+  Optional. Custom definitions used by the filter.
+
+``failregex``
+  Required. Regular expression(s) used by the filter to detect break-in attempts.
+  You can have the filter try to match multiple regular expressions. Each regular
+  expression should be on its own line.
+
+``filename``
+  Optional. Alternative name of the filter configuration file. If not specfied, it
+  will use the ``name`` of the filter.
+
+``ignoreregex``
+  Optional. Regular expression(s) used to filter out invalid break-in attempts. You
+  can have the filter try to match multiple regular expressions. Each regular
+  expression should be on its own line.
+
+``state``
+  Optional. If ``present``, the filter will be created when configuring ``fail2ban``.
+  If ``absent``, the filter will be removed when configuring ``fail2ban``.
+
 .. _fail2ban_jails:
 
 fail2ban_jails

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,6 +15,50 @@
     group: 'root'
   notify: [ 'Reload fail2ban jails' ]
 
+- name: Configure custom fail2ban actions
+  template:
+    src: '{{ lookup("template_src", "etc/fail2ban/action.d/action.local.j2") }}'
+    dest: '/etc/fail2ban/action.d/{{ item.filename | d(item.name) }}.local'
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+  with_items: '{{ fail2ban_actions }}'
+  notify: [ 'Restart fail2ban' ]
+  when: ((item.name is defined and item.name) and
+         (item.ban is defined and item.ban) and
+         (item.state | d('present') not in ['absent']))
+
+- name: Remove custom fail2ban actions if requested
+  file:
+    path: '/etc/fail2ban/action.d/{{ item.filename | d(item.name) }}.local'
+    state: 'absent'
+  with_items: '{{ fail2ban_actions }}'
+  notify: [ 'Restart fail2ban' ]
+  when: ((item.name is defined and item.name) and
+         (item.state | d('present') in ['absent']))
+
+- name: Configure custom fail2ban filters
+  template:
+    src: '{{ lookup("template_src", "etc/fail2ban/filter.d/filter.local.j2") }}'
+    dest: '/etc/fail2ban/filter.d/{{ item.filename | d(item.name) }}.local'
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+  with_items: '{{ fail2ban_filters }}'
+  notify: [ 'Restart fail2ban' ]
+  when: ((item.name is defined and item.name) and
+         (item.failregex is defined and item.failregex) and
+         (item.state | d('present') not in ['absent']))
+
+- name: Remove custom fail2ban filters if requested
+  file:
+    path: '/etc/fail2ban/filter.d/{{ item.filename | d(item.name) }}.local'
+    state: 'absent'
+  with_items: '{{ fail2ban_filters }}'
+  notify: [ 'Restart fail2ban' ]
+  when: ((item.name is defined and item.name) and
+         (item.state | d('present') in ['absent']))
+
 - name: Configure fail2ban
   template:
     src: '{{ lookup("template_src", "etc/fail2ban/fail2ban.local.j2") }}'

--- a/templates/etc/fail2ban/action.d/action.local.j2
+++ b/templates/etc/fail2ban/action.d/action.local.j2
@@ -1,0 +1,13 @@
+# {{ ansible_managed }}
+
+[Definition]
+
+actionstart = {{ item.start | d('') | indent(14) }}
+
+actionstop = {{ item.stop | d('') | indent(13) }}
+
+actioncheck = {{ item.check | d('') | indent(14) }}
+
+actionban = {{ item.ban | indent(12) }}
+
+actionunban = {{ item.unban | d('') | indent(14) }}

--- a/templates/etc/fail2ban/filter.d/filter.local.j2
+++ b/templates/etc/fail2ban/filter.d/filter.local.j2
@@ -1,0 +1,25 @@
+# {{ ansible_managed }}
+
+{% if item.after | d('') or item.before | d('') %}
+[INCLUDES]
+
+{% if item.before | d('') %}
+before = {{ item.before }}
+
+{% endif %}
+{% if item.after | d('') %}
+after = {{ item.after }}
+
+{% endif %}
+{% endif %}
+[Definition]
+
+{% if item.definitions | d({}) %}
+{% for key, value in item.definitions.iteritems() %}
+{{ key }} = {{ value }}
+{% endfor %}
+
+{% endif %}
+failregex = {{ item.failregex | indent(12) }}
+
+ignoreregex = {{ item.ignoreregex | d('') | indent(14) }}


### PR DESCRIPTION
First pass at #3. This adds the ability to create custom actions and filters using dictionaries. This should replace the need for a lot of the files that are in the role. 

For example, `owncloud.local` should be generated by `debops.owncloud`. I didn't remove it yet, but that's something that could be done once the PR gets merged.
