### PR TITLE
Fix loglevel error in fail2ban logs.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,7 +13,8 @@
 # .. envvar:: fail2ban_loglevel
 #
 # Log verbosity
-fail2ban_loglevel: '3'
+# valid values : CRITICAL, ERROR, WARNING, NOTICE, INFO, DEBUG. Default: ERROR
+fail2ban_loglevel: 'WARNING'
 
 
 # .. envvar:: fail2ban_logtarget


### PR DESCRIPTION
Numeral loglevels are not supported.
THe jail.conf manpage advertises : CRITICAL, ERROR, WARNING, NOTICE, INFO, DEBUG. Default: ERROR

This fix the following error message from fail2ban logs (even though fail2ban startup succeed. I expect
it to fallback to the default loglevel).

fail2ban-client[11818]: ERROR  NOK: ('Invalid log level',)
