### PR TITLE
Harmonize SSH jail setup on Debian and Ubuntu

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,25 +1,52 @@
 Changelog
 =========
 
-v0.1.1
-------
+**debops.fail2ban**
 
-*Released: 2016-12-01*
+.. include:: includes/all.rst
+
+This project adheres to `Semantic Versioning <http://semver.org/spec/v2.0.0.html>`__
+and `human-readable changelog <http://keepachangelog.com/en/0.3.0/>`__.
+
+The current role maintainer_ is drybjed_.
+
+
+`debops.fail2ban master`_ - unreleased
+--------------------------------------
+
+.. _debops.fail2ban master: https://github.com/debops/ansible-fail2ban/compare/v0.1.1...master
+
+
+`debops.fail2ban v0.1.1`_ - 2016-12-01
+--------------------------------------
+
+.. _debops.fail2ban v0.1.1: https://github.com/debops/ansible-fail2ban/compare/v0.1.0...v0.1.1
+
+Added
+~~~~~
 
 - Added filter for ownCloud logs [scibi]
 
+- Add support for custom local actions and filters. [carlalexander]
+
+Changed
+~~~~~~~
+
 - Restart fail2ban service instead of reloading it (required for Jessie) [scibi]
 
-- Add support for custom local actions and filters. [carlalexander]
+Fixed
+~~~~~
 
 - Remove Ansible 2.1 deprecation warnings. [carlalexander]
 
 - Fix log level error in :command:`fail2ban` logs. [prahal]
 
-v0.1.0
-------
 
-*Released: 2015-04-10*
+debops.fail2ban v0.1.0 - 2015-04-10
+-----------------------------------
 
-- Initial release [drybjed]
+Added
+~~~~~
+
+- Initial release [drybjed_]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,8 +19,11 @@ The current role maintainer_ is drybjed_.
 Changed
 ~~~~~~~
 
-- Disable default `ssh` jail defined in upstream :file:`jail.conf` and enable
-  it via :envvar:`fail2ban_jails` instead. [ganto_]
+- Harmonize role behaviour on Debian and Ubuntu. Disable the default `ssh` jail
+  defined in the upstream :file:`jail.conf` on Debian. Rename the disabled
+  `ssh-iptables` jail on Ubuntu to `ssh`. [ganto_]
+
+- Enable SSH jail via default configuration of :envvar:`fail2ban_jails`. [ganto_]
 
 
 `debops.fail2ban v0.1.1`_ - 2016-12-01

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,12 @@ The current role maintainer_ is drybjed_.
 
 .. _debops.fail2ban master: https://github.com/debops/ansible-fail2ban/compare/v0.1.1...master
 
+Changed
+~~~~~~~
+
+- Disable default `ssh` jail defined in upstream :file:`jail.conf` and enable
+  it via :envvar:`fail2ban_jails` instead. [ganto_]
+
 
 `debops.fail2ban v0.1.1`_ - 2016-12-01
 --------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,7 +21,9 @@ Changed
 
 - Harmonize role behaviour on Debian and Ubuntu. Disable the default `ssh` jail
   defined in the upstream :file:`jail.conf` on Debian. Rename the disabled
-  `ssh-iptables` jail on Ubuntu to `ssh`. [ganto_]
+  `ssh-iptables` jail on Ubuntu to `ssh`. Ubuntu users which depend on the
+  definition of the `ssh-iptables` jail in :file:`jail.conf` must adjust their
+  configuration. [ganto_]
 
 - Enable SSH jail via default configuration of :envvar:`fail2ban_jails`. [ganto_]
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -170,11 +170,9 @@ fail2ban_filters: []
 #
 # List of dicts which define ``fail2ban`` jails. See :ref:`fail2ban_jails` for
 # more details. This list is meant for all hosts in the cluster.
-fail2ban_jails: []
-
-  # ssh jail is enabled by default in Debian
-  #- name: 'ssh'
-  #  enabled: 'true'
+fail2ban_jails:
+  - name: 'ssh'
+    enabled: 'true'
 
 
 # .. envvar:: fail2ban_group_jails

--- a/docs/includes/all.rst
+++ b/docs/includes/all.rst
@@ -1,0 +1,1 @@
+.. include:: includes/global.rst

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,14 @@
     install_recommends: False
   with_items: [ 'fail2ban', 'whois' ]
 
+- name: Disable default upstream jail
+  lineinfile:
+    dest: '/etc/fail2ban/jail.conf'
+    regexp: '^(enabled  = )true'
+    line: '\1false'
+    backrefs: yes
+  notify: [ 'Reload fail2ban jails' ]
+
 - name: Install custom fail2ban rule files
   copy:
     src: 'etc/fail2ban/'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,17 @@
     install_recommends: False
   with_items: [ 'fail2ban', 'whois' ]
 
+- name: Divert original fail2ban configuration
+  command: dpkg-divert --quiet --local --divert /etc/fail2ban/jail.conf.dpkg-divert --rename /etc/fail2ban/jail.conf
+  args:
+    creates: /etc/fail2ban/jail.conf.dpkg-divert
+
+- name: Copy upstream jail configuration
+  command: cp /etc/fail2ban/jail.conf.dpkg-divert /etc/fail2ban/jail.conf
+  args:
+    creates: '/etc/fail2ban/jail.conf'
+  notify: [ 'Restart fail2ban' ]
+
 - name: Adjust upstream ssh jail configuration
   lineinfile:
     dest: '/etc/fail2ban/jail.conf'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,12 +7,17 @@
     install_recommends: False
   with_items: [ 'fail2ban', 'whois' ]
 
-- name: Disable default upstream jail
+- name: Adjust upstream ssh jail configuration
   lineinfile:
     dest: '/etc/fail2ban/jail.conf'
-    regexp: '^(enabled  = )true'
-    line: '\1false'
+    regexp: '{{ item.regexp }}'
+    line: '{{ item.line }}'
     backrefs: yes
+  with_items:
+    - regexp: '^\[ssh\-iptables\]'
+      line: '[ssh]'
+    - regexp: '^(enabled\s*=\s*)true'
+      line: '\1false'
   notify: [ 'Reload fail2ban jails' ]
 
 - name: Install custom fail2ban rule files


### PR DESCRIPTION
Depending on the distribution and the upstream jail configuration, the outcome of the role is slightly different. On Debian Jessie for example, a default jail `ssh` will be active even when `fail2ban_jails` is empty.

I therefore added a new task to adjust `jail.conf` on the different platforms in a way that it should be possible easily enable the `ssh` jail on all distributions via `fail2ban_jails`. This way it should result in the same setup no matter what distribution is chosen and the default SSH jail can easily be disabled by the user.

If you agree to enable the `ssh` jail by default, I'll still need to update the test suite to make sure the behaviour is as intended on Ubuntu, as I'm locally testing with Debian Jessie.