### PR TITLE
Fixed: Bug "'int' object is not iterable"

### DIFF
--- a/templates/etc/fail2ban/jail.local.d/jail.local.j2
+++ b/templates/etc/fail2ban/jail.local.d/jail.local.j2
@@ -4,10 +4,10 @@
 [{{ item.name }}]
 {% for key, value in item.iteritems() %}
 {%   if key not in [ 'name', 'filename', 'delete', 'comment', 'action', 'ignoreip' ] %}
-{%     if value is string %}
-{{ "%-14s = %s" | format(key, value) }}
-{%     else %}
+{%     if value is iterable and value is not string %}
 {{ "%-14s = %s" | format(key, value | join(",")) }}
+{%     else %}
+{{ "%-14s = %s" | format(key, value) }}
 {%     endif %}
 {%   elif key == 'action' %}
 action         = {{ "%(" + value + ")s" }}


### PR DESCRIPTION
Hi.
When you specifying integer values at `fail2ban_jails` (for example, `maxretry: 2` - without quotes - rather than `maxretry: "2"`) role will fail with error `'int' object is not iterable` because it was tried to `join(,)` anything that is not string. It was easy to get that error (don't like write integers with quotes) but not easy to find. 
Now this fixed. Merge please :)

```
failed: [dev.cardinalcorp.com] (item={u'name': u'ssh', u'enabled': u'true', u'logpath': u'/var/log/auth.log', u'filter': u'sshd', u'maxretry': 6, u'port': u'ssh'}) => {
    "failed": true, 
    "invocation": {
        "module_args": {
            "dest": "/etc/fail2ban/jail.local.d/ssh.local", 
            "group": "root", 
            "mode": "0644", 
            "owner": "root", 
            "src": "etc/fail2ban/jail.local.d/jail.local.j2"
        }, 
        "module_name": "template"
    }, 
    "item": {
        "enabled": "true", 
        "filter": "sshd", 
        "logpath": "/var/log/auth.log", 
        "maxretry": 6, 
        "name": "ssh", 
        "port": "ssh"
    }, 
    "msg": "AnsibleError: Unexpected templating type error occurred on ({% if item.comment is defined and item.comment %}\n# {{ item.comment }}\n{% endif %}\n[{{ item.name }}]\n{% for key, value in item.iteritems() %}\n{%   if key not in [ 'name', 'filename', 'delete', 'comment', 'action', 'ignoreip' ] %}\n{%     if value is string %}\n{{ \"%-14s = %s\" | format(key, value) }}\n{%     else %}\n{{ \"%-14s = %s\" | format(key, value | join(\",\")) }}\n{%     endif %}\n{%   elif key == 'action' %}\naction         = {{ \"%(\" + value + \")s\" }}\n{%   elif key == 'ignoreip' %}\nignoreip       = {{ value | join(\" \") }}\n{%   endif %}\n{% endfor %}\n\n): 'int' object is not iterable"
```