### PR TITLE
Adjust SSH jail name to distribution

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,11 +19,8 @@ The current role maintainer_ is drybjed_.
 Changed
 ~~~~~~~
 
-- Harmonize role behaviour on Debian and Ubuntu. Disable the default `ssh` jail
-  defined in the upstream :file:`jail.conf` on Debian. Rename the disabled
-  `ssh-iptables` jail on Ubuntu to `ssh`. Ubuntu users which depend on the
-  definition of the `ssh-iptables` jail in :file:`jail.conf` must adjust their
-  configuration. [ganto_]
+- Harmonize role behavior on Debian and Ubuntu. Make sure the default SSH jail
+  in the upstream :file:`jail.conf` is disabled. [ganto_]
 
 - Enable SSH jail via default configuration of :envvar:`fail2ban_jails`. [ganto_]
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -171,8 +171,27 @@ fail2ban_filters: []
 # List of dicts which define ``fail2ban`` jails. See :ref:`fail2ban_jails` for
 # more details. This list is meant for all hosts in the cluster.
 fail2ban_jails:
-  - name: 'ssh'
+  - name: '{{ fail2ban_ssh_jail_name }}'
     enabled: 'true'
+
+
+# .. envvar:: fail2ban_ssh_jail_name
+#
+# Most distributions already pre-configure a SSH jail. If the default SSH jail
+# is enabled in :envvar:`fail2ban_jails` make sure the name corresponds with the
+# distributions :file:`jail.conf` to leverage possible ``logpath`` and other
+# service specific configurations.
+fail2ban_ssh_jail_name: '{{ fail2ban_ssh_jail_distribution_map[ansible_distribution_release]
+                            if ansible_distribution_release in fail2ban_ssh_jail_distribution_map.keys()
+                            else "sshd" }}'
+
+
+# .. envvar:: fail2ban_ssh_jail_distribution_map
+#
+# Dictionary for release to default SSH jail name mappings.
+fail2ban_ssh_jail_distribution_map:
+  'trusty': 'ssh'
+  'jessie': 'ssh'
 
 
 # .. envvar:: fail2ban_group_jails

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,17 +18,12 @@
     creates: '/etc/fail2ban/jail.conf'
   notify: [ 'Restart fail2ban' ]
 
-- name: Adjust upstream ssh jail configuration
+- name: Disable default upstream jail
   lineinfile:
     dest: '/etc/fail2ban/jail.conf'
-    regexp: '{{ item.regexp }}'
-    line: '{{ item.line }}'
+    regexp: '^(enabled  = )true'
+    line: '\1false'
     backrefs: yes
-  with_items:
-    - regexp: '^\[ssh\-iptables\]'
-      line: '[ssh]'
-    - regexp: '^(enabled\s*=\s*)true'
-      line: '\1false'
   notify: [ 'Reload fail2ban jails' ]
 
 - name: Install custom fail2ban rule files


### PR DESCRIPTION
Revert one commit from #19 and therefore don't try to be smart and modify default jail names.

Simply define a mapping of distribution to default jail names and call our jail like this. This fixes a regression introduced for some distribution releases (see #20).