### PR TITLE
Change filters failregex

### DIFF
--- a/docs/defaults-configuration.rst
+++ b/docs/defaults-configuration.rst
@@ -67,9 +67,8 @@ List of local ``fail2ban`` filters that should be present or absent when configu
   Optional. Custom definitions used by the filter.
 
 ``failregex``
-  Required. Regular expression(s) used by the filter to detect break-in attempts.
-  You can have the filter try to match multiple regular expressions. Each regular
-  expression should be on its own line.
+  Required. A list of regular expression(s) used by the filter to detect break-in 
+  attempts.
 
 ``filename``
   Optional. Alternative name of the filter configuration file. If not specfied, it

--- a/templates/etc/fail2ban/filter.d/filter.local.j2
+++ b/templates/etc/fail2ban/filter.d/filter.local.j2
@@ -20,6 +20,10 @@ after = {{ item.after }}
 {% endfor %}
 
 {% endif %}
-failregex = {{ item.failregex | indent(12) }}
+failregex = {% for regex in item.failregex %}{% if loop.first %}{{ regex }}
+{% else %}
+            {{ regex }}
+{% endif %}
+{% endfor %}
 
 ignoreregex = {{ item.ignoreregex | d('') | indent(14) }}


### PR DESCRIPTION
Change `fail2ban_filters` `failregex` to a list to support multiple pattern matching.

Example `fail2ban.yml`
```
fail2ban_filters:
  - name: custom_filter
    failregex:
      - '(?i)<HOST> (php|sql|web|pma|/p/m/a/)'
      - '(?i).*admin task.*HTTP.*'
    state: present
```

Reference: https://www.fail2ban.org/wiki/index.php/MANUAL_0_8